### PR TITLE
Enabling disqus comments

### DIFF
--- a/source/_includes/custom/after_footer.html
+++ b/source/_includes/custom/after_footer.html
@@ -1,0 +1,1 @@
+{% include disqus.html %}

--- a/source/_layouts/post.html
+++ b/source/_layouts/post.html
@@ -11,12 +11,14 @@ single: true
         {% include article.html %}
 
       </article>
-    {% if site.disqus_short_name and page.comments == true %}
-      <section>
-        <h1>Comments</h1>
-        <div id="disqus_thread" aria-live="polite">{% include post/disqus_thread.html %}</div>
-      </section>
-    {% endif %}
+    </div>
+    <div class="container">	
+      {% if site.disqus_short_name and page.comments == true %}
+        <section>
+          <h1>Comments</h1>
+          <div id="disqus_thread" aria-live="polite">{% include post/disqus_thread.html %}</div>
+        </section>
+      {% endif %}
     </div>
   </div>
   {% include footer.html %}


### PR DESCRIPTION
My favourite theme for Octopress! but when I installed, Disqus comments were not visible and comment section was at the right side of article. Did a little modification to get the discuss comments running.

Thank you
