### PR TITLE
Use instagram information from config file

### DIFF
--- a/source/_includes/custom/asides/instagram.html
+++ b/source/_includes/custom/asides/instagram.html
@@ -1,5 +1,5 @@
 {% if site.instagram_user %}
 <h2>instagram</h2>
-<div class="instagram"></div>
+<div class="instagram" data-instagram-user="{% site.instagram_user %}" ></div>
 <button id="instabutton" class="btn">more</button>
 {% endif %}


### PR DESCRIPTION
Fixing javascript issue caused by missing data attribute for instagram div, adding the missing data attribute so that javascript can read the information from the div instead of hard coded value
