### PR TITLE
updated readme to use submodule instead of clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,18 @@ This is a theme built for [Octopress](http://Octopress.org) that is a work in pr
 
 ````
 $ cd yourOctopress
-$ git clone https://github.com/sevenadrian/foxslide .themes/foxslide
+$ git submodule add https://github.com/sevenadrian/foxslide .themes/foxslide
+$ git submodule update --init
 $ rake install['foxslide']
 $ rake generate
+````
+
+### Grab the latest updates ###
+
+````
+$ cd yourOctopress
+$ git submodule update
+# regenerate, make changes, etc...
 ````
 
 ## Pull-Requests Welcomed! ##


### PR DESCRIPTION
Hi!

**Amazing** work so far, thanks for this! Saved me so much trouble and BS changing around the default Octopress theme to use bootstrap, etc.

So this pull request concerns the use of git -- instead of cloning into a subdir, Git has this concept of 'submodules' for exactly this use case. Git will let you manage component repos without having to re-commit all the code back to the parent repo, as if it were original code.This could cause issues if people had two different versions of your project cloned and wanted to merge branches, etc.

I've edited the readme to reflect this usage. Thanks again!
