### PR TITLE
Adding back social widgets plus minor formatting tweaks.

### DIFF
--- a/sass/custom/_styles.scss
+++ b/sass/custom/_styles.scss
@@ -1,2 +1,29 @@
 // This File is imported last, and will override other styles in the cascade
 // Add styles here to make changes without digging in too much
+
+// Add back the social sharing CSS
+.sharing {
+  p.meta + & {
+    padding: { top: 1em; left: 0; }
+    margin-bottom: 20px;
+    background: $img-border top left repeat-x;
+  }
+}
+
+#fb-root { display: none; }
+
+// Restore bullets
+.entry-content ol li { list-style: decimal outside none; padding: 0.1em 0 0.5em 0; }
+.entry-content ul li { list-style: disc outside none; padding: 0.1em 0 0.5em 0; }
+
+// Tweak text in the front page widgets area
+p.widgets { margin: 0 0 8px 0; line-height: 1.5; padding-top: 2px; }
+
+// Get rid of box-shadow for individual archive entries
+article.archive-article-format { box-shadow: none; padding: 0; }
+
+// Add a little space between the top of the archive list and the page title
+#blog-archives { margin-top: 30px; }
+
+// Add a little horizontal space in dt elements
+.dl-horizontal dt { width: 135px; }

--- a/source/_includes/archive_post.html
+++ b/source/_includes/archive_post.html
@@ -1,5 +1,5 @@
 {% capture category %}{{ post.categories | size }}{% endcapture %}
-<h1><a href="{{ root_url }}{{ post.url }}">{{post.title}}</a></h1>
+<h2><a href="{{ root_url }}{{ post.url }}">{% if site.titlecase %}{{ post.title | titlecase }}{% else %}{{ post.title }}{% endif %}</a></h2>
 <time datetime="{{ post.date | datetime | date_to_xmlschema }}" pubdate>{{ post.date | date: "<span class='month'>%b</span> <span class='day'>%d</span> <span class='year'>%Y</span>"}}</time>
 {% if category != '0' %}
 <footer>

--- a/source/_includes/article.html
+++ b/source/_includes/article.html
@@ -36,6 +36,9 @@
       {% include post/date.html %}{% if updated %}{{ updated }}{% else %}{{ time }}{% endif %}
       {% include post/categories.html %}
     </p>
+    {% unless page.sharing == false %}
+      {% include post/sharing.html %}
+    {% endunless %}
     {% if page.previous.url %}
       <a class="pull-left" href="{{page.previous.url}}" title="Previous Post: {{page.previous.title}}">&laquo; {{page.previous.title}}</a>
     {% endif %}

--- a/source/_includes/custom/after_footer.html
+++ b/source/_includes/custom/after_footer.html
@@ -1,1 +1,4 @@
 {% include disqus.html %}
+{% include facebook_like.html %}
+{% include google_plus_one.html %}
+{% include twitter_sharing.html %}

--- a/source/_includes/custom/asides/found_on.html
+++ b/source/_includes/custom/asides/found_on.html
@@ -8,7 +8,7 @@
 {% endif %}
 
 {% if site.linkedin_user %}
-<a href="http://www.linkedin.com/in/{{site.linkedin_user}}" rel="tooltip" title="Linkedin"><img class="social_icon" title="Linkedin" alt="Linkedin icon" src="{{ root_url }}/images/glyphicons_377_linked_in.png"></a>
+<a href="http://www.linkedin.com/{{site.linkedin_user}}" rel="tooltip" title="Linkedin"><img class="social_icon" title="Linkedin" alt="Linkedin icon" src="{{ root_url }}/images/glyphicons_377_linked_in.png"></a>
 {% endif %}
 
 {% if site.twitter_user %}

--- a/source/_includes/custom/intro.html
+++ b/source/_includes/custom/intro.html
@@ -1,5 +1,6 @@
 <div class="span10 offset1">
   <h1>
-    I'm <em>{{site.author}}</em>
+    {{site.title}}
   </h1>
+  <h2>{{site.subtitle}}</h2>
 </div>

--- a/source/_layouts/page.html
+++ b/source/_layouts/page.html
@@ -3,7 +3,7 @@
 <nav role="navigation">{% include navigation.html %}</nav>
 <div class="wrapper_single">
   <div class="container">
-    <div class="span8 offset2">
+    <article class="span8 offset2 article-format role="article">
       <div role="div">
         {% if page.title %}
         <header>
@@ -28,7 +28,7 @@
         <div id="disqus_thread" aria-live="polite">{% include post/disqus_thread.html %}</div>
       </section>
     {% endif %}
-    </div>
+    </article>
   </div>
 </div>
 {% include footer.html %}

--- a/source/_layouts/post.html
+++ b/source/_layouts/post.html
@@ -9,16 +9,13 @@ single: true
     <div class="container">
       <article class="span8 offset2" role="article">
         {% include article.html %}
-
+        {% if site.disqus_short_name and page.comments == true %}
+          <div class="article-format">
+            <h1>Comments</h1>
+            <div id="disqus_thread" aria-live="polite">{% include post/disqus_thread.html %}</div>
+          </div>
+        {% endif %}
       </article>
-    </div>
-    <div class="container">	
-      {% if site.disqus_short_name and page.comments == true %}
-        <section>
-          <h1>Comments</h1>
-          <div id="disqus_thread" aria-live="polite">{% include post/disqus_thread.html %}</div>
-        </section>
-      {% endif %}
     </div>
   </div>
   {% include footer.html %}


### PR DESCRIPTION
Added social sharing widgets back to post and page layouts. Tweaked archive archive_post include so that all items are grouped in container, rather than many. Small adjustment to dt element to allow projects with longer names to appear cleanly. Minor LinkedIn link change: the /in path in the URL doesn't seem to be a standard one, so I snipped it.

The theme is great overall! Thanks for making it.

![comments social](https://f.cloud.github.com/assets/3002110/147686/cf315cc8-74c7-11e2-9dc8-53631aecdfde.png)
![archives](https://f.cloud.github.com/assets/3002110/147687/cf2a67e2-74c7-11e2-838c-e909875539a2.png)
