### PR TITLE
Allow Masonry to properly resize elements on browser resize

### DIFF
--- a/source/javascripts/custom.js
+++ b/source/javascripts/custom.js
@@ -76,7 +76,10 @@ $(function(){
   var $container = $('#post-container');
   $container.imagesLoaded(function(){
     $container.masonry({
-      itemSelector : '.span4'
+      itemSelector : '.span4',
+      columnWidth: function( containerWidth ) {
+        return containerWidth / 3;
+      }
     });
   });
 


### PR DESCRIPTION
currently when masonry is enabled resizing the browser screws up the display.
