### PR TITLE
Don't try and use the github object if there's no github user to fetch.

### DIFF
--- a/source/javascripts/custom.js
+++ b/source/javascripts/custom.js
@@ -65,13 +65,16 @@ $(function(){
   });
 
   var githubInfo = $("#gh_repos");
+  if(githubInfo.data('github-user')) {
 
-  github.showRepos({
-    user: githubInfo.data('github-user'),
-    count: githubInfo.data('github-repo-count'),
-    skip_forks: githubInfo.data('github-skip-forks'),
-    target: githubInfo
-  });
+    github.showRepos({
+      user: githubInfo.data('github-user'),
+      count: githubInfo.data('github-repo-count'),
+      skip_forks: githubInfo.data('github-skip-forks'),
+      target: githubInfo
+    });
+  }
+
 
   var $container = $('#post-container');
   $container.imagesLoaded(function(){


### PR DESCRIPTION
A default install was throwing a javascript error because without setting a github user in the config, the `github.js` file isn't included and results in this code block failing.
