### PR TITLE
added dashes to meta paragraph

### DIFF
--- a/source/_includes/article.html
+++ b/source/_includes/article.html
@@ -32,8 +32,8 @@
 {% unless index %}
   <footer>
     <p class="meta">
-      {% include post/author.html %}
-      {% include post/date.html %}{% if updated %}{{ updated }}{% else %}{{ time }}{% endif %}
+      {% include post/author.html %} - 
+      {% include post/date.html %}{% if updated %}{{ updated }}{% else %}{{ time }}{% endif %} - 
       {% include post/categories.html %}
     </p>
     {% unless page.sharing == false %}


### PR DESCRIPTION
The first meta paragraph uses one dash between author and date. It uses another dash between date and categories. The second meta paragraph didn't use any dashes (lack of symmetry bugs me more than it should :p).
