### PR TITLE
External url missing in post title

### DIFF
--- a/source/_includes/article.html
+++ b/source/_includes/article.html
@@ -2,7 +2,12 @@
 {% unless page.no_header %}
   <header>
     {% if index %}
-      <h1 class="entry-title"><a href="{{ root_url }}{{ post.url }}">{% if site.titlecase %}{{ post.title | titlecase }}{% else %}{{ post.title }}{% endif %}</a></h1>
+      {% if post.external-url %}<!-- This defines how Octopress will use posts with external-url. -->
+        <h1 class="entry-title"><a href="{{ post.external-url }}">{% if site.titlecase %}{{ post.title | titlecase }}{% else %}{{ post.title }}{% endif %}</a></h1>
+      {% else %}<!-- Now we're back to normal posts. Note the links used under href in both headers.--> 
+        <h1 class="entry-title"><a href="{{ root_url }}{{ post.url }}">{% if site.titlecase %}{{ post.title | titlecase }}{% else %}{{ post.title }}{% endif %}</a></h1>
+      {% endif %}
+      
     {% else %}
       <h1 class="entry-title">{% if site.titlecase %}{{ page.title | titlecase }}{% else %}{{ page.title }}{% endif %}</h1>
     {% endif %}

--- a/source/_includes/article.html
+++ b/source/_includes/article.html
@@ -29,7 +29,7 @@
 {% if index %}
   <div class="entry-content">{{ content | excerpt }}</div>
   {% if post.external-url %}
-    <footer><a rel="full-article" href="{{ root_url }}{{ post.url }}">{{ site.permalink_label }}Permalink</a></footer>
+    <footer><a rel="full-article" href="{{ root_url }}{{ post.url }}">{{ site.permalink_label_feed }}</a></footer>
   {% endif %}
   {% capture excerpted %}{{ content | has_excerpt }}{% endcapture %}
   {% if excerpted == 'true' %}
@@ -43,7 +43,7 @@
 {% unless index %}
 
 {% if page.external-url %}
-  <footer><a rel="full-article" href="{{ root_url }}{{ post.url }}">{{ site.permalink_label }}Permalink</a></footer>
+  <footer><a rel="full-article" href="{{ root_url }}{{ post.url }}">{{ site.permalink_label }}</a></footer>
 {% endif %}
 
 

--- a/source/_includes/article.html
+++ b/source/_includes/article.html
@@ -29,7 +29,7 @@
 {% if index %}
   <div class="entry-content">{{ content | excerpt }}</div>
   {% if post.external-url %}
-    <footer><a rel="full-article" href="{{ root_url }}{{ post.url }}">Permalink</a></footer>
+    <footer><a rel="full-article" href="{{ root_url }}{{ post.url }}">{{ site.permalink_label }}Permalink</a></footer>
   {% endif %}
   {% capture excerpted %}{{ content | has_excerpt }}{% endcapture %}
   {% if excerpted == 'true' %}
@@ -43,7 +43,7 @@
 {% unless index %}
 
 {% if page.external-url %}
-  <footer><a rel="full-article" href="{{ root_url }}{{ post.url }}">Permalink</a></footer>
+  <footer><a rel="full-article" href="{{ root_url }}{{ post.url }}">{{ site.permalink_label }}Permalink</a></footer>
 {% endif %}
 
 

--- a/source/_includes/article.html
+++ b/source/_includes/article.html
@@ -3,13 +3,16 @@
   <header>
     {% if index %}
       {% if post.external-url %}<!-- This defines how Octopress will use posts with external-url. -->
-        <h1 class="entry-title"><a href="{{ post.external-url }}">{% if site.titlecase %}{{ post.title | titlecase }}{% else %}{{ post.title }}{% endif %}</a></h1>
+        <h1 class="entry-title"><a href="{{ post.external-url }}">{% if site.linklog_marker_position_feed == 'before' %}{{ site.linklog_marker }}{% endif %} {% if site.titlecase %}{{ post.title | titlecase }}{% if site.linklog_marker_position_feed == 'after' %}{{ site.linklog_marker }}{% endif %}{% else %}{{ post.title }}{% endif %}</a></h1>
       {% else %}<!-- Now we're back to normal posts. Note the links used under href in both headers.--> 
         <h1 class="entry-title"><a href="{{ root_url }}{{ post.url }}">{% if site.titlecase %}{{ post.title | titlecase }}{% else %}{{ post.title }}{% endif %}</a></h1>
-      {% endif %}
-      
+      {% endif %}  
     {% else %}
-      <h1 class="entry-title">{% if site.titlecase %}{{ page.title | titlecase }}{% else %}{{ page.title }}{% endif %}</h1>
+      {% if page.external-url %}
+        <h1 class="entry-title"><a href="{{ page.external-url }}">{% if site.titlecase %}{% if site.linklog_marker_position == 'before' %}{{ site.linklog_marker }}{% endif %}{{ page.title | titlecase }}{% if site.linklog_marker_position == 'after' %}{{ site.linklog_marker }}{% endif %}{% else %}{{ page.title }}{% endif %}</a></h1>
+      {% else %}
+        <h1 class="entry-title">{% if site.titlecase %}{{ page.title | titlecase }}{% else %}{{ page.title }}{% endif %}</h1>
+      {% endif %}
     {% endif %}
     {% unless page.meta == false %}
       <p class="meta">
@@ -25,6 +28,9 @@
 {% endunless %}
 {% if index %}
   <div class="entry-content">{{ content | excerpt }}</div>
+  {% if post.external-url %}
+    <footer><a rel="full-article" href="{{ root_url }}{{ post.url }}">Permalink</a></footer>
+  {% endif %}
   {% capture excerpted %}{{ content | has_excerpt }}{% endcapture %}
   {% if excerpted == 'true' %}
     <footer>
@@ -35,6 +41,12 @@
   <div class="entry-content">{{ content }}</div>
 {% endif %}
 {% unless index %}
+
+{% if page.external-url %}
+  <footer><a rel="full-article" href="{{ root_url }}{{ post.url }}">Permalink</a></footer>
+{% endif %}
+
+
   <footer>
     <p class="meta">
       {% include post/author.html %} - 


### PR DESCRIPTION
added support for  [octopress linklog](http://octopress.org/docs/blogging/linklog/)

Implemented similar code as in here: http://www.candlerblog.com/2012/01/30/octopress-linked-list/
