### PR TITLE
Use pagination path, rather than pagination page number

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -27,12 +27,12 @@ layout: default
         <ul class="pager">
           {% if paginator.next_page %}
             <li class="previous">
-              <a href="{{paginator.next_page}}">&larr; Older</a>
+              <a href="{{paginator.next_page_path}}">&larr; Older</a>
             </li>
           {% endif %}
           {% if paginator.previous_page %}
             <li class="next">
-              <a class="next" href="{{paginator.previous_page}}">Newer &rarr;</a>
+              <a class="next" href="{{paginator.previous_page_path}}">Newer &rarr;</a>
             </li>
           {% endif %}
         </ul>


### PR DESCRIPTION
Switch from paginator.next|previous_page to paginator.next|previous_page_path so that the full path, and not just the page number is used for the "Older" and "Newer" links.
