### PR TITLE
Fix centering page and post articles

### DIFF
--- a/source/_layouts/page.html
+++ b/source/_layouts/page.html
@@ -3,32 +3,34 @@
 <nav role="navigation">{% include navigation.html %}</nav>
 <div class="wrapper_single">
   <div class="container">
-    <article class="span8 offset2 article-format" role="article">
-      <div role="div">
-        {% if page.title %}
-        <header>
-          <h1 class="entry-title">{% if site.titlecase %}{{ page.title | titlecase }}{% else %}{{ page.title }}{% endif %}</h1>
-          {% if page.date %}<p class="meta">{% include post/date.html %}{{ time }}</p>{% endif %}
-        </header>
-        {% endif %}
-        {{ content }}
-        {% unless page.footer == false %}
-          <footer>
-            {% if page.date or page.author %}<p class="meta">
-              {% if page.author %}{% include post/author.html %}{% endif %}
-              {% include post/date.html %}{% if updated %}{{ updated }}{% else %}{{ time }}{% endif %}
-              {% if page.categories %}{% include post/categories.html %}{% endif %}
-            </p>{% endif %}
-          </footer>
-        {% endunless %}
-      </div>
-    {% if site.disqus_short_name and page.comments == true %}
-      <section>
-        <h1>Comments</h1>
-        <div id="disqus_thread" aria-live="polite">{% include post/disqus_thread.html %}</div>
-      </section>
-    {% endif %}
-    </article>
+    <div class="row">
+      <article class="span8 offset2 article-format" role="article">
+        <div role="div">
+          {% if page.title %}
+          <header>
+            <h1 class="entry-title">{% if site.titlecase %}{{ page.title | titlecase }}{% else %}{{ page.title }}{% endif %}</h1>
+            {% if page.date %}<p class="meta">{% include post/date.html %}{{ time }}</p>{% endif %}
+          </header>
+          {% endif %}
+          {{ content }}
+          {% unless page.footer == false %}
+            <footer>
+              {% if page.date or page.author %}<p class="meta">
+                {% if page.author %}{% include post/author.html %}{% endif %}
+                {% include post/date.html %}{% if updated %}{{ updated }}{% else %}{{ time }}{% endif %}
+                {% if page.categories %}{% include post/categories.html %}{% endif %}
+              </p>{% endif %}
+            </footer>
+          {% endunless %}
+        </div>
+      {% if site.disqus_short_name and page.comments == true %}
+        <section>
+          <h1>Comments</h1>
+          <div id="disqus_thread" aria-live="polite">{% include post/disqus_thread.html %}</div>
+        </section>
+      {% endif %}
+      </article>
+    </div>
   </div>
 </div>
 {% include footer.html %}

--- a/source/_layouts/post.html
+++ b/source/_layouts/post.html
@@ -7,15 +7,17 @@ single: true
   <nav role="navigation">{% include navigation.html %}</nav>
   <div class="wrapper_single">
     <div class="container">
-      <article class="span8 offset2" role="article">
-        {% include article.html %}
-        {% if site.disqus_short_name and page.comments == true %}
-          <div class="article-format">
-            <h1>Comments</h1>
-            <div id="disqus_thread" aria-live="polite">{% include post/disqus_thread.html %}</div>
-          </div>
-        {% endif %}
-      </article>
+      <div class="row">
+        <article class="span8 offset2" role="article">
+          {% include article.html %}
+          {% if site.disqus_short_name and page.comments == true %}
+            <div class="article-format">
+              <h1>Comments</h1>
+              <div id="disqus_thread" aria-live="polite">{% include post/disqus_thread.html %}</div>
+            </div>
+          {% endif %}
+        </article>
+      </div>
     </div>
   </div>
   {% include footer.html %}


### PR DESCRIPTION
Add divs with Bootstrap's row class so that grid system works correctly. The use of Bootstrap spans and offsets on the article elements did not properly center the content due to lack of a parent row. See line 6 of source/_layouts/page.html and line 10 of source/_layouts/post.html (of new commit).
