### PR TITLE
Update to fix date not displaying with current Octopress master

### DIFF
--- a/source/_includes/post/date.html
+++ b/source/_includes/post/date.html
@@ -1,15 +1,5 @@
-{% capture date %}{{ page.date }}{{ post.date }}{% endcapture %}
-{% capture date_formatted %}{{ page.date_formatted }}{{ post.date_formatted }}{% endcapture %}
-{% capture has_date %}{{ date | size }}{% endcapture %}
+{% if page.date %}{% capture time %}{{ page.date_time_html }}{% endcapture %}{% endif %}
+{% if post.date %}{% capture time %}{{ post.date_time_html }}{% endcapture %}{% endif %}
 
-{% capture updated %}{{ page.updated }}{{ post.updated }}{% endcapture %}
-{% capture updated_formatted %}{{ page.updated_formatted }}{{ post.updated_formatted }}{% endcapture %}
-{% capture was_updated %}{{ updated | size }}{% endcapture %}
-
-{% if has_date != '0' %}
-  {% capture time %}<time datetime="{{ date | datetime | date_to_xmlschema }}" pubdate{% if updated %} data-updated="true"{% endif %}>{{ date_formatted }}</time>{% endcapture %}
-{% endif %}
-
-{% if was_updated != '0' %}
-  {% capture updated %}<time datetime="{{ updated | datetime | date_to_xmlschema }}" class="updated">Updated {{ updated_formatted }}</time>{% endcapture %}
-{% else %}{% assign updated = false %}{% endif %}
+{% if page.updated %}{% capture updated %}{{ page.date_time_updated_html }}{% endcapture %}{% endif %}
+{% if post.updated %}{% capture updated %}{{ post.date_time_updated_html }}{% endcapture %}{% endif %}


### PR DESCRIPTION
The current Octopress master branch breaks dates for themes. A similar fix for the classic theme that comes with Octopress for reference can be found here:

https://github.com/imathis/octopress/commit/73e540409ceb8bc18048b6a96a4b815fc303ea28
